### PR TITLE
Add 'name' and 'post' tables to .ttx

### DIFF
--- a/tofu.ttx
+++ b/tofu.ttx
@@ -126,6 +126,9 @@
   <loca>
   </loca>
 
+  <name>
+  </name>
+  
   <glyf> <!-- Will result in empty table -->
     <TTGlyph name=".notdef"/>
     <TTGlyph name="glyph00001">
@@ -155,5 +158,17 @@
             00000001  <!-- glyphID -->
     </hexdata>
   </cmap>
+
+  <post>
+    <formatType value="3.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-100"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+  </post>
 
 </ttFont>


### PR DESCRIPTION
I have been trying to use the tiny tofu font available on 
https://github.com/behdad/tofudetector (2 years after this original discussion)

chrome 54 - complains that there are missing tables :'name' and 'post'
When I add those and regenerate the ttf, the tofu font works as expected in chrome :-)

firefox 50 - the font does not work (either with or without the 'name' and 'post' tables). The console does not complain of anything

Firefox seem to have accepted the OTS modifications and I don't understand why the font does not work as expected. Do you know how I could debug this ?

IE 11 - the font does not work (either with or without the 'name' and 'post' tables). The console says "CSS3111: @font-face encountered unknown error."

I have no idea how I could have more information from IE / windows on what goes wrong. If you have any idea your are welcome.

The current embedded CSS I use is

    @font-face {
      font-family: 'tofu';
      src: url(data:application/x-font-ttf;charset=utf-8;base64,AAEAAAAKAIAAAwAgT1MvMkXLAyYAAAEoAAAAYGNtYXAAIQA0AAABkAAAAChnbHlmJSMnJAAAAcAAAAAaaGVhZAnrg7sAAACsAAAANmhoZWEMAZwDAAAA5AAAACRobXR4WAAAAAAAAYgAAAAIbG9jYQANAAAAAAG4AAAABm1heHAABAAFAAABCAAAACBuYW1lAAYAAAAAAdwAAAAGcG9zdP+fADIAAAHkAAAAIAABAAAAAQAA9DQI5V8PPPUAAAgAAAAAAM53qgAAAAAA1GCMxQIAAAAGAAgAAAAAAQACAAAAAAAAAAEAAAgAAAAAAFAAAABMAAQAAAEAAAAAAAAAAAAAAAAAAAACAAEAAAACAAQAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAwMWAZAABQAABZoFMwAAAR8FmgUzAAAD0QBmAgAKAgIABQYAAAACAAOAAAAvQAAASgAAAAAAAAAAICAgIABAACD7BAgA/gAAAAgAAgAAAAAFAAAAAAQABf4AAAAgAAMIAAAAUAAAAAAAAAEAAwAKAAAADAANAAAAAAAcAAAAAAAAAAEAAAABABD//gAAAAEAAAAAAA0AAAABAgAAAAYACAAAAwAAISERIQIABAD8AAgAAAAAAAAAAAYAAAADAAAAAAAA/5wAMgAAAAAAAAAAAAAAAAAAAAAAAAAA);
      font-weight:normal;
      font-style:normal;
    }

generated from the .ttx in this PR.



